### PR TITLE
Don't set stream duration when unknown

### DIFF
--- a/src/com/google/sample/castcompanionlibrary/utils/Utils.java
+++ b/src/com/google/sample/castcompanionlibrary/utils/Utils.java
@@ -449,14 +449,17 @@ public class Utils {
                 LOGE(TAG, "Failed to build media tracks from the wrapper bundle", e);
             }
         }
-        return new MediaInfo.Builder(wrapper.getString(KEY_URL))
+        MediaInfo.Builder builder = new MediaInfo.Builder(wrapper.getString(KEY_URL))
                 .setStreamType(wrapper.getInt(KEY_STREAM_TYPE))
                 .setContentType(wrapper.getString(KEY_CONTENT_TYPE))
                 .setMetadata(metaData)
                 .setCustomData(customData)
-                .setMediaTracks(mediaTracks)
-                .setStreamDuration(wrapper.getLong(KEY_STREAM_DURATION))
-                .build();
+                .setMediaTracks(mediaTracks);
+        long duration = wrapper.getLong(KEY_STREAM_DURATION);
+        if (duration != MediaInfo.UNKNOWN_DURATION) {
+            builder.setStreamDuration(duration);
+        }
+        return builder.build();
     }
 
     /**


### PR DESCRIPTION
Deserialization of MediaInfo instances from Bundle data in [Utils#toMediaInfo](https://github.com/googlecast/CastCompanionLibrary-android/blob/master/src/com/google/sample/castcompanionlibrary/utils/Utils.java#L458) sets the stream duration regardless of its value. Since a live stream (STREAM_TYPE_LIVE) has a duration of [UNKNOWN_DURATION](https://developer.android.com/reference/com/google/android/gms/cast/MediaInfo.html#UNKNOWN_DURATION) this leads to an IllegalArgumentException in [MediaInfo.Builder#setStreamDuration](https://developer.android.com/reference/com/google/android/gms/cast/MediaInfo.Builder.html#setStreamDuration(long)).

Utils#toMediaInfo is used in [VideoCastControllerFragment](https://github.com/googlecast/CastCompanionLibrary-android/blob/master/src/com/google/sample/castcompanionlibrary/cast/player/VideoCastControllerFragment.java#L146).