### PR TITLE
Receiver app should stop when the 'X' in the Notification gets tapped.

### DIFF
--- a/src/com/google/sample/castcompanionlibrary/remotecontrol/VideoIntentReceiver.java
+++ b/src/com/google/sample/castcompanionlibrary/remotecontrol/VideoIntentReceiver.java
@@ -68,7 +68,11 @@ public class VideoIntentReceiver extends BroadcastReceiver {
             try {
                 if (null != castMgr) {
                     LOGD(TAG, "Calling stopApplication from intent");
-                    castMgr.disconnect();
+                    //Disconnect isn't enough
+                    //castMgr.disconnect();
+                    
+                    //https://developers.google.com/cast/docs/design_checklist#sender-control-notification
+                    castMgr.stopApplication();
                 } else {
                     startService(context, VideoCastNotificationService.ACTION_STOP);
                 }


### PR DESCRIPTION
...notification

Regarding a bug report by Google the receiver application should close  and disconnect all senders when the 'X' in the notification gets tapped.