### PR TITLE
Fixed Null Pointer Exception on Building Lockscreen after disconnect

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "23"
+    buildToolsVersion "23.0.1"
     publishNonDefault true
 
     defaultConfig {

--- a/src/com/google/android/libraries/cast/companionlibrary/cast/VideoCastManager.java
+++ b/src/com/google/android/libraries/cast/companionlibrary/cast/VideoCastManager.java
@@ -2268,8 +2268,13 @@ public class VideoCastManager extends BaseCastManager
             new FetchBitmapTask() {
                 @Override
                 protected void onPostExecute(Bitmap bitmap) {
-                    MediaMetadataCompat currentMetadata = mMediaSessionCompat.getController()
-                            .getMetadata();
+                    MediaMetadataCompat currentMetadata;
+                    try {
+                      currentMetadata = mMediaSessionCompat.getController().getMetadata();
+                    }
+                    catch (Exception e) {
+                      //TODO: Do Something with the Caught Exception
+                    }
                     MediaMetadataCompat.Builder newBuilder = currentMetadata == null
                             ? new MediaMetadataCompat.Builder()
                             : new MediaMetadataCompat.Builder(currentMetadata);


### PR DESCRIPTION
When Clicking on Stop Casting while the Bitmap Lock Screen Runs its fetch bitmap task, the Application tries to Access getController().getMetadata(). However since we already disconnected, getController() will return null  and result in a crash.

```
java.lang.NullPointerException: Attempt to invoke virtual method 'android.support.v4.media.session.MediaControllerCompat android.support.v4.media.session.MediaSessionCompat.getController()' on a null object reference
            at com.google.android.libraries.cast.companionlibrary.cast.VideoCastManager$29.onPostExecute(VideoCastManager.java:2271)
            at com.google.android.libraries.cast.companionlibrary.cast.VideoCastManager$29.onPostExecute(VideoCastManager.java:2268)
            at android.os.AsyncTask.finish(AsyncTask.java:636)
            at android.os.AsyncTask.access$500(AsyncTask.java:177)
            at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:653)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5254)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```