### PR TITLE
Add permissions to Manifest to prevent lint error

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,6 +17,9 @@
     package="com.google.android.libraries.cast.companionlibrary"
     android:versionCode="17"
     android:versionName="2.1" >
+    
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <uses-sdk
         android:minSdkVersion="10"


### PR DESCRIPTION
A (new?) lint check prevents release builds of the  CastCompanionLibrary because the permissions ACCESS_WIFI_STATE and INTERNET are not declared. Since the CCL is pretty useless without the permissions I see no problems with adding them in the library.