### PR TITLE
Handle failure to load media

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -53,6 +53,7 @@
 
     <!-- Failures -->
     <string name="ccl_failed_to_connect">Could not connect to the device</string>
+    <string name="ccl_failed_to_load_media">Cast device failed to load media</string>
     <string name="ccl_failed_setting_volume">Failed to set the volume</string>
     <string name="ccl_failed_no_connection">No connection to the cast device is present</string>
     <string name="ccl_failed_no_connection_short">No connection</string>

--- a/src/com/google/android/libraries/cast/companionlibrary/cast/player/VideoCastControllerFragment.java
+++ b/src/com/google/android/libraries/cast/companionlibrary/cast/player/VideoCastControllerFragment.java
@@ -19,6 +19,7 @@ package com.google.android.libraries.cast.companionlibrary.cast.player;
 import static com.google.android.libraries.cast.companionlibrary.utils.LogUtils.LOGD;
 import static com.google.android.libraries.cast.companionlibrary.utils.LogUtils.LOGE;
 
+import com.google.android.gms.cast.CastStatusCodes;
 import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.cast.MediaQueueItem;
@@ -239,6 +240,15 @@ public class VideoCastControllerFragment extends Fragment implements
                 updateMetadata();
             } catch (TransientNetworkDisconnectionException | NoConnectionException e) {
                 LOGE(TAG, "Failed to update the metadata due to network issues", e);
+            }
+        }
+
+        @Override
+        public void onMediaLoadResult(int statusCode) {
+            if (CastStatusCodes.SUCCESS != statusCode) {
+                LOGD(TAG, "onMediaLoadResult(): " + CastStatusCodes.getStatusCodeString(statusCode));
+                Utils.showToast(getActivity(), R.string.ccl_failed_to_load_media);
+                mCastController.closeActivity();
             }
         }
 


### PR DESCRIPTION
Currently, the VideoCastController stays in "Loading" state when loading media failed.

VideoCastConsumerImpl.onMediaLoadResult() reports load result but from outside the VideoCastControllerActivity/Fragment, it is difficult/impossible to change the controller screen.

Similarly to onFailed(), I suggest to handle onMediaLoadResult() in MyCastConsumer in VideoCastControllerFragment by showing a toast with a specific error message and closing the VideoCastController activity (to return to the previous activity).