### PR TITLE
Removing error-causing dimension value used in IntroductoryOverlay

### DIFF
--- a/res/values-land/dimens.xml
+++ b/res/values-land/dimens.xml
@@ -18,5 +18,4 @@
     <!-- Introductory Overlay -->
     <dimen name="ccl_intro_text_margin">36dp</dimen>
     <dimen name="ccl_intro_button_margin_right">52dp</dimen>
-    <dimen name="ccl_intro_button_margin_bottom">10dp</dimen>
 </resources>


### PR DESCRIPTION
If showing an activity with the IntroductoryOverlay in landscape on a device running API v21 or above with the navigation bar, the OK button will overlap the navigation bar and will be difficult to press (see [screenshot](https://imgur.com/3n3hxwF)).
Removing this dimension value in values-land/ will let it fall back to the value in values-v21in this case (40dp), which moves the button to the expected position. If the device's OS version is <21 it will fall back to the value in values/, which is the same anyway (10dp), so this shouldn't affect other devices.

This can be reproduced in the CastVideos app, though you'll need to remove the _screenOrientation_ attribute in _VideoBrowserActivity_ in the manifest to let it display in landscape. 